### PR TITLE
Add support for selecting subscription offers by Offer ID in GoogleSales

### DIFF
--- a/lib/core/src/main/java/com/zuko/billingz/core/store/model/OfferDetails.kt
+++ b/lib/core/src/main/java/com/zuko/billingz/core/store/model/OfferDetails.kt
@@ -24,6 +24,8 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class OfferDetails(
+    override val offerId: String?,
+    override val basePlanId: String,
     override val offerTags: List<String>,
     override val offerToken: String,
     override val offers: List<Offer>

--- a/lib/core/src/main/java/com/zuko/billingz/core/store/model/Productz.kt
+++ b/lib/core/src/main/java/com/zuko/billingz/core/store/model/Productz.kt
@@ -137,6 +137,8 @@ interface Productz : ModuleIdentifier {
      * For Google Play SubscriptionOfferDetails support
      */
     interface OfferDetails {
+        val offerId: String?
+        val basePlanId: String
         val offerTags: List<String>
         val offerToken: String
         val offers: List<Offer>

--- a/lib/core/src/main/java/com/zuko/billingz/core/store/sales/Optionz.kt
+++ b/lib/core/src/main/java/com/zuko/billingz/core/store/sales/Optionz.kt
@@ -10,7 +10,8 @@ object Optionz {
         OLD_PURCHASE_TOKEN,
         IS_PERSONALIZED_OFFER,
         REGION,
-        SELECTED_OFFER_INDEX
+        SELECTED_OFFER_INDEX,
+        SELECTED_OFFER_ID
     }
 
     enum class Region {
@@ -43,6 +44,7 @@ object Optionz {
         private var oldPurchaseToken: String? = null
         private var oldSubId: String? = null
         private var selectedOfferIndex = -1
+        private var selectedOfferId: String? = null
 
         override fun setConsumerRegion(region: Region): Builder {
             this.region = region
@@ -74,6 +76,11 @@ object Optionz {
             return this
         }
 
+        override fun setSelectedOfferId(offerId: String): Builder {
+            selectedOfferId = offerId
+            return this
+        }
+
         override fun build(): Bundle {
             val bundle = Bundle()
             bundle.putString(Type.OLD_SUB_ID.name, oldSubId)
@@ -85,6 +92,7 @@ object Optionz {
             bundle.putInt(Type.REGION.name, region.ordinal)
             bundle.putBoolean(Type.IS_PERSONALIZED_OFFER.name, isOfferPersonalized)
             bundle.putInt(Type.SELECTED_OFFER_INDEX.name, selectedOfferIndex)
+            bundle.putString(Type.SELECTED_OFFER_ID.name, selectedOfferId)
             return bundle
         }
     }
@@ -129,6 +137,12 @@ object Optionz {
          * be purchased.
          */
         fun setSelectedOfferIndex(index: Int): Builder
+
+        /**
+         * Set the offer id of the relevant Subscription OfferDetails to
+         * be purchased.
+         */
+        fun setSelectedOfferId(offerId: String): Builder
 
         /**
          * Create [Bundle] object of order options.

--- a/lib/google/src/main/java/com/zuko/billingz/google/store/model/GoogleProduct.kt
+++ b/lib/google/src/main/java/com/zuko/billingz/google/store/model/GoogleProduct.kt
@@ -153,6 +153,8 @@ data class GoogleProduct(
             offers.add(o)
         }
         return OfferDetails(
+            offerId = offer.offerId,
+            basePlanId = offer.basePlanId,
             offerTags = offer.offerTags,
             offerToken = offer.offerToken,
             offers = offers


### PR DESCRIPTION
# Support for Subscription Offer Selection by ID

This PR introduces the ability to select subscription offers by their unique `offerId` when initiating a purchase flow with Google Play Billing.

## Key Changes

*   **Core Models**: Updated `OfferDetails` and `Productz.OfferDetails` to include `offerId` and `basePlanId`.
*   **Options Builder**: Added `SELECTED_OFFER_ID` to `Optionz` to allow developers to specify a target offer ID.
*   **Google Sales Logic**: Enhanced `GoogleSales` to prioritize offer resolution by `offerId` if provided, falling back to index or the default offer.

## Benefits

*   More reliable and explicit offer targeting compared to index-based selection.
*   Improved compatibility with Google Play Billing Library 5+ subscription structures.


## ☑️ PR Checklist

<!-- Please review and check each box accordingly. All boxes must be checked before a review process can begin. -->

<!-- These checkboxes are clickable once you open the PR -->
Please check each box of requirements:[^1]
- [x] Did you test your changes?
- [ ] Did you add any new test classes and/or update existing tests?
- [x] Did you provide any necessary documentation for your code changes?

## 🏷 Pull request label

Please select one box that best describes your PR:[^1]
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (linting, formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (gradle, scripts, etc)
- [ ] Documentation content changes
- [ ] Other (please describe):

## 🛑 Does this introduce a breaking change?

- [ ] Yes
- [x] No

❤️Thank you!

[^1]: [Github Markdown Docs](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists)
